### PR TITLE
Feat: Added The Export Poll Feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,10 +82,15 @@
                     <!-- Chart.js canvas for results -->
                     <canvas id="results-chart"></canvas>
                 </div>
-                <button id="back-to-polls" class="btn-secondary">Back to My Polls</button>
-            </section>
+                <div id="results-display">
+    <canvas id="results-chart"></canvas>
+</div>
+<button id="export-results-btn" class="btn-primary">Export Results (JSON)</button>
+<button id="back-to-polls" class="btn-secondary">Back to My Polls</button>
         </main>
     </div>
+            </section> 
+
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -51,6 +51,11 @@ class MicroPoll {
             this.displayPolls();
         });
 
+        // Export Results
+document.getElementById('export-results-btn').addEventListener('click', () => {
+    this.exportResults();
+});
+
         // Dynamic option removal
         document.addEventListener('click', (e) => {
             if (e.target.classList.contains('remove-option')) {
@@ -260,6 +265,32 @@ class MicroPoll {
     });
 
     this.showSection('results-section');
+}
+
+exportResults() {
+    if (!this.currentPoll) return;
+
+    const exportData = {
+        question: this.currentPoll.question,
+        type: this.currentPoll.type,
+        totalVotes: this.currentPoll.totalVotes,
+        createdAt: this.currentPoll.createdAt,
+        results: this.currentPoll.options.map(opt => ({
+            option: opt.text,
+            votes: opt.votes,
+            percentage: this.currentPoll.totalVotes > 0 
+                ? ((opt.votes / this.currentPoll.totalVotes) * 100).toFixed(2) + '%'
+                : '0%'
+        }))
+    };
+
+    const dataStr = JSON.stringify(exportData, null, 2);
+    const dataBlob = new Blob([dataStr], { type: 'application/json' });
+    
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(dataBlob);
+    link.download = `poll-results-${Date.now()}.json`;
+    link.click();
 }
 
 


### PR DESCRIPTION
## Add Export Poll Results Feature

### Changes
- Added `exportResults()` method to export poll data as JSON
- Includes question, vote counts, and calculated percentages
- New "Export Results" button on results page
- Downloads as timestamped JSON file - which can be used for further analysis

### Why
Allows users to save and share poll results outside the app for reports, analysis, or backup purposes.

### Files Modified
- `script.js` - Added export method and event listener
- `index.html` - Added export button to results section

Image:
<img width="935" height="849" alt="image" src="https://github.com/user-attachments/assets/e82a3f3e-a3ee-441f-8dea-5f077d55ed3f" />
<img width="587" height="447" alt="image" src="https://github.com/user-attachments/assets/1a97b4c0-4d76-4a8d-a3f2-43e91c75d22b" />

